### PR TITLE
Llama index pyfunc wrapper

### DIFF
--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -1,20 +1,159 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from llama_index.core import QueryBundle
+from llama_index.core.llms import ChatMessage
+
+from mlflow.models.utils import _convert_llm_input_data
 
 CHAT_ENGINE_NAME = "chat"
 QUERY_ENGINE_NAME = "query"
 RETRIEVER_ENGINE_NAME = "retriever"
 SUPPORTED_ENGINES = {CHAT_ENGINE_NAME, QUERY_ENGINE_NAME, RETRIEVER_ENGINE_NAME}
 
+_CHAT_MESSAGE_PARAMETER_NAMES = {"query", "message"}
+_CHAT_MESSAGE_HISTORY_PARAMETER_NAMES = {"messages", "chat_history"}
 
-# NOTE: will add this in the next PR
+
+class _LlamaIndexModelWrapperBase:
+    def __init__(
+        self,
+        index,
+        model_config: Optional[Dict[str, Any]] = None,
+    ):
+        self.index = index
+        self.model_config = model_config or {}
+        self.predict_callable = self._build_engine_method()
+
+    def _build_engine_method(self) -> Callable:
+        raise NotImplementedError
+
+    def _format_predict_input(self, data):
+        raise NotImplementedError
+
+    def _do_inference(self, input, params: Optional[Dict[str, Any]]) -> Dict:
+        """
+        Perform engine inference on a single engine input e.g. not an iterable of
+        engine inputs. The engine inputs must already be preprocessed/cleaned.
+        """
+
+        if isinstance(input, dict):
+            return self.predict_callable(**input, **(params or {}))
+        else:
+            return self.predict_callable(input, **(params or {}))
+
+    def predict(self, data, params: Optional[Dict[str, Any]] = None) -> Union[List[str], str]:
+        data = self._format_predict_input(data)
+
+        if isinstance(data, list):
+            return [self._do_inference(x, params) for x in data]
+        else:
+            return self._do_inference(data, params)
+
+
+class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.engine_type = CHAT_ENGINE_NAME
+
+    def _build_engine_method(self) -> Callable:
+        return self.index.as_chat_engine(**self.model_config).chat
+
+    @staticmethod
+    def _parse_dict_as_chat_message_objects(data: dict) -> dict:
+        message_matches = (name for name in _CHAT_MESSAGE_PARAMETER_NAMES if name in data)
+        if (key := next(message_matches, None)) and data.get(key):
+            if not isinstance(data[key], str):
+                raise ValueError(f"{key} must be a str. Got: {data[key]}")
+
+        message_history_matches = (
+            name for name in _CHAT_MESSAGE_HISTORY_PARAMETER_NAMES if name in data
+        )
+        if (key := next(message_history_matches, None)) and data.get(key):
+            if isinstance(data[key], list):
+                for i, message in enumerate(data[key]):
+                    if isinstance(message, dict):
+                        data[key][i] = ChatMessage(**message)
+
+            if not all(isinstance(message, ChatMessage) for message in data[key]):
+                raise ValueError(f"{key} must be a list of ChatMessage objects. Got: {data[key]}")
+
+        return data
+
+    def _format_predict_input(self, data):
+        """
+        Chat engines can have a variety of signatures. The two primary standards are:
+        1. chat(str, Sequence[ChatMessage])
+        2. chat(Sequence[ChatMessage])
+
+        There are not consistent naming conventions for either of these standards, so
+        we'll need to leverage positional arguments.
+        """
+        data = _convert_llm_input_data(data)
+
+        if isinstance(data, str):
+            return data
+        elif isinstance(data, dict):
+            return self._parse_dict_as_chat_message_objects(data)
+        elif isinstance(data, list):
+            prediction_input = [self._format_predict_input(d) for d in data]
+            return prediction_input if len(prediction_input) > 1 else prediction_input[0]
+        else:
+            raise ValueError(
+                f"Unsupported input type: {type(data)}. It must be one of "
+                "[str, dict, list, numpy.ndarray, pandas.DataFrame]"
+            )
+
+
+class QueryEngineWrapper(_LlamaIndexModelWrapperBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.engine_type = QUERY_ENGINE_NAME
+
+    def _build_engine_method(self) -> Callable:
+        return self.index.as_query_engine(**self.model_config).query
+
+    def _format_predict_input(self, data):
+        """Convert pyfunc input to a QueryBundle."""
+        data = _convert_llm_input_data(data)
+
+        if isinstance(data, str):
+            return QueryBundle.from_dict({"query_str": data})
+        elif isinstance(data, dict):
+            try:
+                return QueryBundle.from_dict(data)
+            except KeyError:
+                raise ValueError(
+                    "The input dictionary did not have the correct schema. It must support the "
+                    "supported in a llama_index QueryBundle: "
+                    "['query_str', 'image_path', 'custom_embedding_strs', 'embedding']"
+                )
+        elif isinstance(data, list):
+            prediction_input = [self._format_predict_input(d) for d in data]
+            return prediction_input if len(prediction_input) > 1 else prediction_input[0]
+        else:
+            raise ValueError(
+                f"Unsupported input type: {type(data)}. It must be one of "
+                "[str, dict, list, numpy.ndarray, pandas.DataFrame]"
+            )
+
+
+class RetrieverEngineWrapper(QueryEngineWrapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.engine_type = RETRIEVER_ENGINE_NAME
+
+    def _build_engine_method(self) -> Callable:
+        return self.index.as_retriever(**self.model_config).retrieve
+
+
 def create_engine_wrapper(index, engine_type: str, model_config: Optional[Dict[str, Any]] = None):
-    class _EngineWrapper:
-        def __init__(self, index, engine_type, model_config):
-            self.index = index
-            self.engine_type = engine_type
-            self.model_config = model_config
-
-        def predict(self, data, params: Optional[Dict[str, Any]] = None) -> Union[List[str], str]:
-            return "placeholder"
-
-    return _EngineWrapper(index, engine_type, model_config)
+    if engine_type == QUERY_ENGINE_NAME:
+        return QueryEngineWrapper(index, model_config)
+    elif engine_type == CHAT_ENGINE_NAME:
+        return ChatEngineWrapper(index, model_config)
+    elif engine_type == RETRIEVER_ENGINE_NAME:
+        return RetrieverEngineWrapper(index, model_config)
+    else:
+        raise ValueError(
+            f"Unsupported engine type: {engine_type}. It must be one of {SUPPORTED_ENGINES}"
+        )

--- a/tests/llama_index/test_llama_index_pyfunc_wrapper.py
+++ b/tests/llama_index/test_llama_index_pyfunc_wrapper.py
@@ -1,0 +1,233 @@
+import pandas as pd
+import pytest
+from llama_index.core import QueryBundle
+from llama_index.core.base.response.schema import (
+    NodeWithScore,
+    Response,
+)
+from llama_index.core.chat_engine.types import (
+    AgentChatResponse,
+)
+from llama_index.core.llms import ChatMessage
+
+from mlflow.llama_index.pyfunc_wrapper import (
+    _CHAT_MESSAGE_HISTORY_PARAMETER_NAMES,
+    _CHAT_MESSAGE_PARAMETER_NAMES,
+    CHAT_ENGINE_NAME,
+    QUERY_ENGINE_NAME,
+    RETRIEVER_ENGINE_NAME,
+    SUPPORTED_ENGINES,
+    create_engine_wrapper,
+)
+
+from tests.llama_index._llama_index_test_fixtures import (
+    document,  # noqa: F401
+    embed_model,  # noqa: F401
+    multi_index,  # noqa: F401
+    settings,  # noqa: F401
+    single_graph,  # noqa: F401
+    single_index,  # noqa: F401
+    spark,  # noqa: F401
+)
+
+
+@pytest.mark.parametrize("engine_type", SUPPORTED_ENGINES)
+def test_create_create_engine_wrapper(single_index, engine_type):
+    wrapped_model = create_engine_wrapper(single_index, engine_type)
+    assert wrapped_model is not None
+    assert wrapped_model.engine_type == engine_type
+    assert engine_type in str(wrapped_model.predict_callable)
+
+
+################## Inferece Input #################
+def test_format_predict_input_str_chat(single_index):
+    wrapped_model = create_engine_wrapper(single_index, CHAT_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input("string")
+    assert isinstance(formatted_data, str)
+
+
+def test_format_predict_input_dict_chat(single_index):
+    wrapped_model = create_engine_wrapper(single_index, CHAT_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input({"query": "string"})
+    assert isinstance(formatted_data, dict)
+
+
+@pytest.mark.parametrize(
+    ("query_key", "chat_history_key"),
+    [
+        (query_key, chat_history_key)
+        for query_key in _CHAT_MESSAGE_PARAMETER_NAMES
+        for chat_history_key in _CHAT_MESSAGE_HISTORY_PARAMETER_NAMES
+    ],
+)
+def test_format_predict_input_message_history_chat(single_index, query_key, chat_history_key):
+    payload = {
+        "query": "string",
+        "message_history": [{"role": "user", "content": "hi"}] * 3,
+    }
+    wrapped_model = create_engine_wrapper(single_index, CHAT_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(payload)
+
+    assert isinstance(formatted_data, dict)
+    assert formatted_data["query"] == payload["query"]
+    assert isinstance(formatted_data["message_history"], list)
+    assert all(isinstance(x, dict) for x in formatted_data["message_history"])
+    assert ChatMessage(**formatted_data["message_history"][0])
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [
+            {
+                "query": "string",
+                "message_history": [{"role": "user", "content": "hi"}] * 3,
+            }
+        ]
+        * 3,
+        pd.DataFrame(
+            [
+                {
+                    "query": "string",
+                    "message_history": [{"role": "user", "content": "hi"}] * 3,
+                }
+            ]
+            * 3
+        ),
+    ],
+)
+def test_format_predict_input_message_history_chat_iterable(single_index, data):
+    wrapped_model = create_engine_wrapper(single_index, CHAT_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(data)
+
+    if isinstance(data, pd.DataFrame):
+        data = data.to_dict("records")
+
+    assert isinstance(formatted_data, list)
+    assert formatted_data[0]["query"] == data[0]["query"]
+    assert isinstance(formatted_data[0]["message_history"], list)
+    assert all(isinstance(x, dict) for x in formatted_data[0]["message_history"])
+    assert ChatMessage(**formatted_data[0]["message_history"][0])
+
+
+def test_format_predict_input_message_history_chat_invalid(single_index):
+    payload = {"query": "string", "message_history": ["invalid history string", "user: hi"]}
+    wrapped_model = create_engine_wrapper(single_index, CHAT_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(payload)
+
+    assert isinstance(formatted_data, dict)
+    assert formatted_data["query"] == payload["query"]
+    assert isinstance(formatted_data["message_history"], list)
+    assert not any(isinstance(x, ChatMessage) for x in formatted_data["message_history"])
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        "string",
+        ["string"],  # iterables of length 1 should be treated non-iterables
+        {"query_str": "string"},
+        {"query_str": "string", "custom_embedding_strs": ["string"], "embedding": [1.0]},
+        pd.DataFrame(
+            {"query_str": ["string"], "custom_embedding_strs": [["string"]], "embedding": [[1.0]]}
+        ),
+    ],
+)
+def test_format_predict_input_no_iterable_query(single_index, data):
+    wrapped_model = create_engine_wrapper(single_index, QUERY_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(data)
+    assert isinstance(formatted_data, QueryBundle)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["string", "string"],
+        [{"query_str": "string"}] * 4,
+        [{"query_str": "string", "custom_embedding_strs": ["string"], "embedding": [1.0]}] * 4,
+        [
+            pd.DataFrame(
+                {
+                    "query_str": ["string"],
+                    "custom_embedding_strs": [["string"]],
+                    "embedding": [[1.0]],
+                }
+            )
+        ]
+        * 2,
+    ],
+)
+def test_format_predict_input_iterable_query(single_index, data):
+    wrapped_model = create_engine_wrapper(single_index, QUERY_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(data)
+
+    assert isinstance(formatted_data, list)
+    assert all(isinstance(x, QueryBundle) for x in formatted_data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        "string",
+        ["string"],  # iterables of length 1 should be treated non-iterables
+        {"query_str": "string"},
+        {"query_str": "string", "custom_embedding_strs": ["string"], "embedding": [1.0]},
+        pd.DataFrame(
+            {"query_str": ["string"], "custom_embedding_strs": [["string"]], "embedding": [[1.0]]}
+        ),
+    ],
+)
+def test_format_predict_input_no_iterable_retriever(single_index, data):
+    wrapped_model = create_engine_wrapper(single_index, RETRIEVER_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(data)
+    assert isinstance(formatted_data, QueryBundle)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["string", "string"],
+        [{"query_str": "string"}] * 4,
+        [{"query_str": "string", "custom_embedding_strs": ["string"], "embedding": [1.0]}] * 4,
+        [
+            pd.DataFrame(
+                {
+                    "query_str": ["string"],
+                    "custom_embedding_strs": [["string"]],
+                    "embedding": [[1.0]],
+                }
+            )
+        ]
+        * 2,
+    ],
+)
+def test_format_predict_input_iterable_retriever(single_index, data):
+    wrapped_model = create_engine_wrapper(single_index, RETRIEVER_ENGINE_NAME)
+    formatted_data = wrapped_model._format_predict_input(data)
+    assert isinstance(formatted_data, list)
+    assert all(isinstance(x, QueryBundle) for x in formatted_data)
+
+
+#### E2E Inference ####
+def test_predict_query(single_index):
+    payload = "string"
+    wrapped_model = create_engine_wrapper(single_index, "chat")
+    predictions = wrapped_model.predict(payload)
+    assert isinstance(predictions, AgentChatResponse)
+    assert predictions.response
+
+
+def test_predict_query(single_index):
+    payload = "string"
+    wrapped_model = create_engine_wrapper(single_index, "query")
+    predictions = wrapped_model.predict(payload)
+    assert isinstance(predictions, Response)
+    assert predictions.response
+
+
+def test_predict_query(single_index):
+    payload = "string"
+    wrapped_model = create_engine_wrapper(single_index, "retriever")
+    predictions = wrapped_model.predict(payload)
+    assert isinstance(predictions, list)
+    assert isinstance(predictions[0], NodeWithScore)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/michael-berk/mlflow/pull/4?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/4/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 4
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- Add pyfunc wrapper with classes for each llama index engine
- Add associated tests

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
